### PR TITLE
Updating DLNA/UPNP code:

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/security/DLNAAuthenticationProvider.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/security/DLNAAuthenticationProvider.java
@@ -1,0 +1,39 @@
+package org.airsonic.player.security;
+
+import org.airsonic.player.service.SettingsService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class DLNAAuthenticationProvider implements AuthenticationProvider {
+
+    @Autowired
+    SettingsService settingsService;
+
+    @Override
+    public Authentication authenticate(Authentication auth) throws AuthenticationException {
+        DLNAAuthenticationToken token = (DLNAAuthenticationToken) auth;
+        if (settingsService.isDlnaEnabled() && token.getRequestedPath() != null && (
+            token.getRequestedPath().startsWith("ext/coverArt.view") ||
+            token.getRequestedPath().startsWith("ext/stream"))) {
+            return new DLNAAuthenticationToken(token.getPrincipal(), "cred", token.getRequestedPath(), DLNA_AUTHORITIES, token);
+        }
+        return null;
+    }
+
+    public static List<GrantedAuthority> DLNA_AUTHORITIES = List.of(
+            new SimpleGrantedAuthority("IS_AUTHENTICATED_FULLY"),
+            new SimpleGrantedAuthority("ROLE_TEMP"));
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return DLNAAuthenticationToken.class.isAssignableFrom(authentication);
+    }
+}

--- a/airsonic-main/src/main/java/org/airsonic/player/security/DLNAAuthenticationToken.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/security/DLNAAuthenticationToken.java
@@ -1,0 +1,31 @@
+package org.airsonic.player.security;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+
+public class DLNAAuthenticationToken extends UsernamePasswordAuthenticationToken {
+
+    private String requestedPath;
+
+    public DLNAAuthenticationToken(Object principal, Object credentials, String requestedPath) {
+        super(principal, credentials);
+        this.requestedPath = requestedPath;
+    }
+
+    public DLNAAuthenticationToken(Object principal, Object credentials, String requestedPath, Collection<? extends GrantedAuthority> authorities) {
+        super(principal, credentials, authorities);
+        this.requestedPath = requestedPath;
+    }
+
+    public DLNAAuthenticationToken(Object principal, Object credentials, String requestedPath,
+            Collection<? extends GrantedAuthority> authorities, Object details) {
+        this(principal, credentials, requestedPath, authorities);
+        this.setDetails(details);
+    }
+
+    public String getRequestedPath() {
+        return requestedPath;
+    }
+}

--- a/airsonic-main/src/main/java/org/airsonic/player/security/DLNARequestParameterProcessingFilter.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/security/DLNARequestParameterProcessingFilter.java
@@ -1,0 +1,119 @@
+package org.airsonic.player.security;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.util.Optional;
+
+public class DLNARequestParameterProcessingFilter implements Filter {
+    private static final Logger LOG = LoggerFactory.getLogger(DLNARequestParameterProcessingFilter.class);
+    private final AuthenticationManager authenticationManager;
+    private final AuthenticationFailureHandler failureHandler;
+
+    public static final String DLNA_AUTH_PARAMETER = "dlnaAuth";
+
+    protected DLNARequestParameterProcessingFilter(AuthenticationManager authenticationManager, String failureUrl) {
+        this.authenticationManager = authenticationManager;
+        failureHandler = new SimpleUrlAuthenticationFailureHandler(failureUrl);
+    }
+
+    public Authentication attemptAuthentication(Optional<DLNAAuthenticationToken> token) throws AuthenticationException {
+        if (token.isPresent()) {
+            return authenticationManager.authenticate(token.get());
+        }
+        throw new AuthenticationServiceException("Invalid auth method");
+    }
+
+    private Optional<DLNAAuthenticationToken> findToken(HttpServletRequest request) {
+        return Optional.ofNullable(request.getParameter(DLNA_AUTH_PARAMETER))
+                .filter(StringUtils::isNotEmpty)
+                .map(t -> new DLNAAuthenticationToken(findHostname(request), t, request.getRequestURI().substring(request.getContextPath().length() + 1)));
+    }
+
+    private String findHostname(HttpServletRequest request) {
+        String userAgent = request.getHeader("User-Agent");
+        String host = request.getRemoteHost();
+        return userAgent == null ? host : userAgent + "/" + host;
+    }
+
+    @Override
+    public void init(FilterConfig filterConfig) {
+    }
+
+    @Override
+    public void doFilter(ServletRequest req, ServletResponse resp, FilterChain chain) throws IOException,
+            ServletException {
+        HttpServletRequest request = (HttpServletRequest) req;
+        HttpServletResponse response = (HttpServletResponse) resp;
+
+        LOG.debug("dlna doing filter");
+        Optional<DLNAAuthenticationToken> token = findToken(request);
+        if (!token.isPresent()) {
+            chain.doFilter(req, resp);
+            return;
+        }
+        LOG.debug("dlna token present");
+
+        Authentication authResult;
+
+        try {
+            authResult = attemptAuthentication(token);
+            if (authResult == null) {
+                // return immediately as subclass has indicated that it hasn't completed
+                // authentication
+                return;
+            }
+        } catch (InternalAuthenticationServiceException failed) {
+            LOG.error(
+                    "An internal error occurred while trying to authenticate the user.",
+                    failed);
+            unsuccessfulAuthentication(request, response, failed);
+
+            return;
+        } catch (AuthenticationException e) {
+            unsuccessfulAuthentication(request, response, e);
+            return;
+        }
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Authentication success. Updating SecurityContextHolder to contain: "
+                    + authResult);
+        }
+
+        SecurityContextHolder.getContext().setAuthentication(authResult);
+
+        chain.doFilter(request, response);
+    }
+
+    protected void unsuccessfulAuthentication(HttpServletRequest request,
+                                              HttpServletResponse response, AuthenticationException failed)
+            throws IOException, ServletException {
+        SecurityContextHolder.clearContext();
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Authentication request failed: " + failed.toString(), failed);
+            LOG.debug("Updated SecurityContextHolder to contain null Authentication");
+            LOG.debug("Delegating to authentication failure handler " + failureHandler);
+        }
+
+        failureHandler.onAuthenticationFailure(request, response, failed);
+    }
+
+    @Override
+    public void destroy() {
+    }
+
+}

--- a/airsonic-main/src/main/java/org/airsonic/player/security/GlobalSecurityConfig.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/security/GlobalSecurityConfig.java
@@ -55,6 +55,9 @@ public class GlobalSecurityConfig {
     @Autowired
     private SonosJWTVerification sonosJwtVerification;
 
+    @Autowired
+    private DLNAAuthenticationProvider dlnaAuthProvider;
+
     @EventListener
     public void loginFailureListener(AbstractAuthenticationFailureEvent event) {
         if (event.getSource() instanceof AbstractAuthenticationToken) {
@@ -91,6 +94,7 @@ public class GlobalSecurityConfig {
         jwtAuth.addAdditionalCheck("/ws/Sonos", sonosJwtVerification);
         auth.authenticationProvider(jwtAuth);
         auth.authenticationProvider(multipleCredsProvider);
+        auth.authenticationProvider(dlnaAuthProvider);
     }
 
     @Bean
@@ -108,6 +112,7 @@ public class GlobalSecurityConfig {
                 authenticationManager,
                 FAILURE_URL)
             , UsernamePasswordAuthenticationFilter.class);
+        http = http.addFilterBefore(new DLNARequestParameterProcessingFilter(authenticationManager, FAILURE_URL), UsernamePasswordAuthenticationFilter.class);
 
         http
                 .securityMatcher("/ext/**")

--- a/airsonic-main/src/main/java/org/airsonic/player/service/SettingsService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/SettingsService.java
@@ -116,7 +116,7 @@ public class SettingsService {
     private static final String KEY_SORT_ALBUMS_BY_YEAR = "SortAlbumsByYear";
     private static final String KEY_DLNA_ENABLED = "DlnaEnabled";
     private static final String KEY_DLNA_SERVER_NAME = "DlnaServerName";
-    private static final String KEY_DLNA_SERVER_ID = "DlnaServerId";
+    private static final String KEY_DLNA_SERVER_ID_OVERRIDE = "DlnaServerIdOverride";
     private static final String KEY_DLNA_BASE_LAN_URL = "DlnaBaseLANURL";
     private static final String KEY_UPNP_PORT = "UPnpPort";
     private static final String KEY_SONOS_ENABLED = "SonosEnabled";
@@ -1257,12 +1257,12 @@ public class SettingsService {
         setString(KEY_DLNA_SERVER_NAME, dlnaServerName);
     }
 
-    public String getDlnaServerId() {
-        return getString(KEY_DLNA_SERVER_ID, DEFAULT_DLNA_SERVER_ID); // default is null
+    public String getDlnaServerIdOverride() {
+        return getString(KEY_DLNA_SERVER_ID_OVERRIDE, DEFAULT_DLNA_SERVER_ID); // default is null
     }
 
-    public void setDlnaServerId(String dlnaServerId) {
-        setString(KEY_DLNA_SERVER_ID, dlnaServerId);
+    public void setDlnaServerIdOverride(String dlnaServerId) {
+        setString(KEY_DLNA_SERVER_ID_OVERRIDE, dlnaServerId);
     }
 
     public String getDlnaBaseLANURL() {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/upnp/AlbumUpnpProcessor.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/upnp/AlbumUpnpProcessor.java
@@ -99,13 +99,13 @@ public class AlbumUpnpProcessor extends UpnpContentProcessor <Album, MediaFile> 
         } else {
             container.setId(getRootId() + DispatchingContentDirectory.SEPARATOR + album.getId());
             container.setAlbumArtURIs(new URI[] { upnpUtil.getAlbumArtURI(album.getId()) });
-            container.setDescription(album.getComment());
+            container.setDescription(UpnpUtil.sanitizeXml(album.getComment()));
         }
         container.setParentID(getRootId());
-        container.setTitle(album.getName());
+        container.setTitle(UpnpUtil.sanitizeXml(album.getName()));
         // TODO: correct artist?
         if (album.getArtist() != null) {
-            container.setArtists(getAlbumArtists(album.getArtist()));
+            container.setArtists(getAlbumArtists(UpnpUtil.sanitizeXml(album.getArtist())));
         }
         return container;
     }

--- a/airsonic-main/src/main/java/org/airsonic/player/service/upnp/ArtistUpnpProcessor.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/upnp/ArtistUpnpProcessor.java
@@ -76,7 +76,7 @@ public class ArtistUpnpProcessor extends UpnpContentProcessor <Artist, Album> {
         MusicArtist container = new MusicArtist();
         container.setId(getRootId() + DispatchingContentDirectory.SEPARATOR + artist.getId());
         container.setParentID(getRootId());
-        container.setTitle(artist.getName());
+        container.setTitle(UpnpUtil.sanitizeXml(artist.getName()));
         container.setChildCount(artist.getAlbumCount());
 
         return container;

--- a/airsonic-main/src/main/java/org/airsonic/player/service/upnp/DispatchingContentDirectory.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/upnp/DispatchingContentDirectory.java
@@ -82,6 +82,9 @@ public class DispatchingContentDirectory extends CustomContentDirectory {
                 returnValue = browseFlag == BrowseFlag.METADATA ? processor.browseObjectMetadata(itemId)
                         : processor.browseObject(itemId, filter, firstResult, maxResults, orderBy);
             }
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("upnp request returning result {}", returnValue.getResult());
+            }
             return returnValue;
         } catch (Throwable x) {
             LOG.error("UPnP error: " + x, x);

--- a/airsonic-main/src/main/java/org/airsonic/player/service/upnp/FolderBasedContentDirectory.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/upnp/FolderBasedContentDirectory.java
@@ -201,10 +201,10 @@ public class FolderBasedContentDirectory extends CustomContentDirectory {
         MusicTrack item = new MusicTrack();
         item.setId(String.valueOf(song.getId()));
         item.setParentID(String.valueOf(parent.getId()));
-        item.setTitle(song.getTitle());
-        item.setAlbum(song.getAlbumName());
+        item.setTitle(UpnpUtil.sanitizeXml(song.getTitle()));
+        item.setAlbum(UpnpUtil.sanitizeXml(song.getAlbumName()));
         if (song.getArtist() != null) {
-            item.setArtists(new PersonWithRole[]{new PersonWithRole(song.getArtist())});
+            item.setArtists(new PersonWithRole[]{new PersonWithRole(UpnpUtil.sanitizeXml(song.getArtist()))});
         }
         Integer year = song.getYear();
         if (year != null) {
@@ -212,10 +212,10 @@ public class FolderBasedContentDirectory extends CustomContentDirectory {
         }
         item.setOriginalTrackNumber(song.getTrackNumber());
         if (song.getGenre() != null) {
-            item.setGenres(new String[]{song.getGenre()});
+            item.setGenres(new String[]{UpnpUtil.sanitizeXml(song.getGenre())});
         }
         item.setResources(Arrays.asList(upnpUtil.createResourceForSong(song)));
-        item.setDescription(song.getComment());
+        item.setDescription(UpnpUtil.sanitizeXml(song.getComment()));
         item.addProperty(new DIDLObject.Property.UPNP.ALBUM_ART_URI(upnpUtil.getAlbumArtURI(parent.getId())));
 
         return item;
@@ -224,7 +224,7 @@ public class FolderBasedContentDirectory extends CustomContentDirectory {
     private Container createContainer(MediaFile mediaFile) {
         Container container = mediaFile.isAlbum() ? createAlbumContainer(mediaFile) : new MusicAlbum();
         container.setId(CONTAINER_ID_FOLDER_PREFIX + mediaFile.getId());
-        container.setTitle(mediaFile.getName());
+        container.setTitle(UpnpUtil.sanitizeXml(mediaFile.getName()));
         List<MediaFile> children = mediaFileService.getVisibleChildrenOf(mediaFile, true, false);
         container.setChildCount(children.size());
 
@@ -266,8 +266,8 @@ public class FolderBasedContentDirectory extends CustomContentDirectory {
         PlaylistContainer container = new PlaylistContainer();
         container.setId(CONTAINER_ID_PLAYLIST_PREFIX + playlist.getId());
         container.setParentID(CONTAINER_ID_PLAYLIST_ROOT);
-        container.setTitle(playlist.getName());
-        container.setDescription(playlist.getComment());
+        container.setTitle(UpnpUtil.sanitizeXml(playlist.getName()));
+        container.setDescription(UpnpUtil.sanitizeXml(playlist.getComment()));
         container.setChildCount(playlistService.getFilesInPlaylist(playlist.getId()).size());
 
         return container;

--- a/airsonic-main/src/main/java/org/airsonic/player/service/upnp/MediaFileUpnpProcessor.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/upnp/MediaFileUpnpProcessor.java
@@ -92,7 +92,7 @@ public class MediaFileUpnpProcessor extends UpnpContentProcessor <MediaFile, Med
             container.setDescription(item.getComment());
         }
         container.setId(getRootId() + DispatchingContentDirectory.SEPARATOR + item.getId());
-        container.setTitle(item.getName());
+        container.setTitle(UpnpUtil.sanitizeXml(item.getName()));
         List<MediaFile> children = getChildren(item);
         container.setChildCount(children.size());
 
@@ -154,10 +154,10 @@ public class MediaFileUpnpProcessor extends UpnpContentProcessor <MediaFile, Med
         MusicTrack item = new MusicTrack();
         item.setId(String.valueOf(song.getId()));
         item.setParentID(String.valueOf(parent.getId()));
-        item.setTitle(song.getTitle());
-        item.setAlbum(song.getAlbumName());
+        item.setTitle(UpnpUtil.sanitizeXml(song.getTitle()));
+        item.setAlbum(UpnpUtil.sanitizeXml(song.getAlbumName()));
         if (song.getArtist() != null) {
-            item.setArtists(router.getAlbumProcessor().getAlbumArtists(song.getArtist()));
+            item.setArtists(router.getAlbumProcessor().getAlbumArtists(UpnpUtil.sanitizeXml(song.getArtist())));
         }
         Integer year = song.getYear();
         if (year != null) {
@@ -165,10 +165,10 @@ public class MediaFileUpnpProcessor extends UpnpContentProcessor <MediaFile, Med
         }
         item.setOriginalTrackNumber(song.getTrackNumber());
         if (song.getGenre() != null) {
-            item.setGenres(new String[]{song.getGenre()});
+            item.setGenres(new String[]{UpnpUtil.sanitizeXml(song.getGenre())});
         }
         item.setResources(Arrays.asList(upnpUtil.createResourceForSong(song)));
-        item.setDescription(song.getComment());
+        item.setDescription(UpnpUtil.sanitizeXml(song.getComment()));
         item.addProperty(new DIDLObject.Property.UPNP.ALBUM_ART_URI(upnpUtil.getAlbumArtURI(parent.getId())));
 
         return item;

--- a/airsonic-main/src/main/java/org/airsonic/player/service/upnp/PlaylistUpnpProcessor.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/upnp/PlaylistUpnpProcessor.java
@@ -52,8 +52,8 @@ public class PlaylistUpnpProcessor extends UpnpContentProcessor <Playlist, Media
         PlaylistContainer container = new PlaylistContainer();
         container.setId(getRootId() + DispatchingContentDirectory.SEPARATOR + item.getId());
         container.setParentID(getRootId());
-        container.setTitle(item.getName());
-        container.setDescription(item.getComment());
+        container.setTitle(UpnpUtil.sanitizeXml(item.getName()));
+        container.setDescription(UpnpUtil.sanitizeXml(item.getComment()));
         container.setChildCount(playlistService.getFilesInPlaylist(item.getId()).size());
 
         return container;


### PR DESCRIPTION
switching from using JWT to using a trivial auth (since enabling DLNA means that you're making your library freely available to play anyway, so a JWT is overkill)

restoring previous functionality where you could override the UPNP serverId, thus ensuring consistency through hardware and network device changes

sanitizing XML-non-compliant characters from id3 tags so that crufty tags don't crash the dlna output